### PR TITLE
Fix issue #6 installation instructions and missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ For proper lemmatization of all languages for LLM evaluation, the following pack
 cd evaluation
 pip install konlpy
 pip install hausastemmer
-git clone https://github.com/aznlp-disc/stemmer.git,
-cp stemmer/word.txt ./evaluation
-cp stemmer/suffix.txt ./evaluation
+git clone https://github.com/aznlp-disc/stemmer.git
+cp stemmer/words.txt .
+cp stemmer/suffix.txt .
 pip install nlp-id
 pip install hazm
 pip install qalsadi

--- a/evaluation/exact_match.py
+++ b/evaluation/exact_match.py
@@ -8,7 +8,7 @@ from konlpy.tag import Okt
 # pip install hausastemmer
 import hausastemmer
 
-# git clone https://github.com/aznlp-disc/stemmer.git, cp word.txt & suffix.txt.
+# git clone https://github.com/aznlp-disc/stemmer.git, cp words.txt & suffix.txt.
 from stemmer.stemmer import Stemmer as AZStemmer
 from string import punctuation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cltk==1.3.0
 cohere==5.5.6
 easydict==1.12
 google_cloud_aiplatform==1.43.0
+google-generativeai==0.8.6
 hausastemmer==1.0
 hazm==0.10.0
 jieba==0.42.1


### PR DESCRIPTION
Fixes #6

## Summary
- Correct README quick-install stemmer commands
- Add missing `google-generativeai` dependency in `requirements.txt`
- Align `evaluation/exact_match.py` comment with `words.txt`